### PR TITLE
Set background of code box to black

### DIFF
--- a/css/theme/hbz.css
+++ b/css/theme/hbz.css
@@ -153,7 +153,7 @@ body {
   overflow: auto;
   max-height: 400px;
   word-wrap: normal;
-  background: #3F3F3F;
+  background: #000000;
   color: #DCDCDC; }
 
 .reveal table {

--- a/lib/css/zenburn.css
+++ b/lib/css/zenburn.css
@@ -7,7 +7,7 @@ based on dark.css by Ivan Sagalaev
   display: block;
   overflow-x: auto;
   padding: 0.5em;
-  background: #3f3f3f;
+  background: #000000;
   color: #dcdcdc;
   -webkit-text-size-adjust: none;
 }


### PR DESCRIPTION
Improves readability.

This _should_ set the color of the code box to black but it doesn't do it :(
Any idea?